### PR TITLE
Remove commented-out code in MjpegFileWriter

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -158,17 +158,6 @@ public class MjpegFileWriter implements AutoCloseable {
         }
     }
 
-    // public void writeAVI(File file) throws Exception
-    // {
-    // OutputStream os = new FileOutputStream(file);
-    //
-    // // RIFFHeader
-    // // AVIMainHeader
-    // // AVIStreamList
-    // // AVIStreamHeader
-    // // AVIStreamFormat
-    // // write 00db and image bytes...
-    // }
     public static int swapInt(int v) {
         return (v >>> 24) | (v << 24) | ((v << 8) & 0x00FF0000) | ((v >> 8) & 0x0000FF00);
     }


### PR DESCRIPTION
The MjpegFileWriter class should have clean, maintainable code without any unnecessary commented-out sections. The code should focus only on the actual functionality, improving readability and reducing distractions.

Removed line from 162 to 172 for better readability. 

issue is not reproducible and fixed now.