### PR TITLE
The block of commented-out lines of code is removed to avoid technical debt

### DIFF
--- a/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-android/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -369,13 +369,6 @@ public class MjpegFileWriter {
     }
 
     private class AVIStreamFormat {
-        /*
-         * FOURCC fcc; DWORD cb; DWORD biSize; LONG biWidth; LONG biHeight; WORD
-         * biPlanes; WORD biBitCount; DWORD biCompression; DWORD biSizeImage;
-         * LONG biXPelsPerMeter; LONG biYPelsPerMeter; DWORD biClrUsed; DWORD
-         * biClrImportant;
-         */
-
         public byte[] fcc = new byte[]{'s', 't', 'r', 'f'};
         public int cb = 40;
         public int biSize = 40;                               // same


### PR DESCRIPTION
Commented-out code distracts the focus from the actual executed code. It creates a noise that increases maintenance code and because it is never executed, it quickly becomes out of date and invalid. That is why I deleted the commented-out code.