### PR TITLE
Removing these useless parentheses

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/system/AWTComponentRenderer.java
+++ b/jme3-desktop/src/main/java/com/jme3/system/AWTComponentRenderer.java
@@ -328,7 +328,7 @@ public class AWTComponentRenderer {
             imageDataBuffer[i] =   ((0xff & byteBuffer[i*4+3]) << 24)  // Alpha 
                                  | ((0xff & byteBuffer[i*4])   << 16)  // Red
                                  | ((0xff & byteBuffer[i*4+1]) <<  8)  // Green 
-                                 | ((0xff & byteBuffer[i*4+2]));       // BLue
+                | (0xff & byteBuffer[i * 4 + 2]); // BLue
             
           }
         }


### PR DESCRIPTION
There is a useless parentheses. Parentheses can disambiguate the order of operations in complex expressions and make the code easier to understand.Redundant parentheses are parenthesis that do not change the behavior of the code, and do not clarify the intent. They can mislead and complexify the code and it causes technical debt. They should be removed.