### PR TITLE
This block of commented-out lines of code should be removed

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
+++ b/jme3-desktop/src/main/java/com/jme3/app/state/MjpegFileWriter.java
@@ -219,15 +219,6 @@ public class MjpegFileWriter implements AutoCloseable {
     }
 
     private class AVIMainHeader {
-        /*
-         *
-         * FOURCC fcc; DWORD cb; DWORD dwMicroSecPerFrame; DWORD
-         * dwMaxBytesPerSec; DWORD dwPaddingGranularity; DWORD dwFlags; DWORD
-         * dwTotalFrames; DWORD dwInitialFrames; DWORD dwStreams; DWORD
-         * dwSuggestedBufferSize; DWORD dwWidth; DWORD dwHeight; DWORD
-         * dwReserved[4];
-         */
-
         public byte[] fcc = new byte[]{'a', 'v', 'i', 'h'};
         public int cb = 56;
         public int dwMicroSecPerFrame = 0;                                // (1


### PR DESCRIPTION
In the file MjpegFileWriter.java, there is a block of commented-out code. Commented-out code distracts the focus from the actual executed code. It creates a noise that increases maintenance code. And because it is never executed, it quickly becomes out of date and invalid which is a technical debt and that's why the commented-out code should be deleted and can be retrieved from source control history if required.