### PR TITLE
Code removal of unused method in file AWTLoader.java

### DIFF
--- a/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
+++ b/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java
@@ -87,19 +87,6 @@ public class AWTLoader implements AssetLoader {
             System.arraycopy(sln, 0,         img, y2 * scSz, scSz);
         }
     }
-    
-    private void flipImage(short[] img, int width, int height, int bpp){
-        int scSz = (width * bpp) / 8;
-        scSz /= 2; // Because shorts are 2 bytes
-        short[] sln = new short[scSz];
-        int y2 = 0;
-        for (int y1 = 0; y1 < height / 2; y1++){
-            y2 = height - y1 - 1;
-            System.arraycopy(img, y1 * scSz, sln, 0,         scSz);
-            System.arraycopy(img, y2 * scSz, img, y1 * scSz, scSz);
-            System.arraycopy(sln, 0,         img, y2 * scSz, scSz);
-        }
-    }
 
     public Image load(BufferedImage img, boolean flipY){
         int width = img.getWidth();


### PR DESCRIPTION
Fixing the clones detected through PDM and CPD tools.

Files Detected:
---
[jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java](https://github.com/meetkalariya/jmonkeyengineFall2024/blob/Code_Removal_40244748/jme3-desktop/src/main/java/com/jme3/texture/plugins/AWTLoader.java)

Impact Analysis:
---
The flipImage method was removed after determining it had zero references or dependencies within the codebase, meaning it was not called or relied upon by any other part of the application. This cleanup improves code maintainability by eliminating unused methods, reducing potential confusion for future developers. Additionally, removing unused code can reduce potential technical debt and improve overall performance. In contrast, another method with three usages was retained to preserve required functionality.

Gradle clean install:
---
![image](https://github.com/user-attachments/assets/31024aee-fa39-4f84-8e69-da433f749246)

ScreenShot after refactoring:
---
![image](https://github.com/user-attachments/assets/8d377cf0-c466-48d1-b6e9-3394c7df9046)


